### PR TITLE
Disable automatic reconnection

### DIFF
--- a/src/frontends/android/jni/libandroidbridge/backend/android_service.c
+++ b/src/frontends/android/jni/libandroidbridge/backend/android_service.c
@@ -724,7 +724,7 @@ static job_requeue_t initiate(private_android_service_t *this)
 	peer_cfg->add_auth_cfg(peer_cfg, auth, FALSE);
 
 	child_cfg = child_cfg_create("android", &lifetime, NULL, TRUE, MODE_TUNNEL,
-								 ACTION_NONE, ACTION_RESTART, ACTION_RESTART,
+								 ACTION_NONE, ACTION_NONE, ACTION_NONE,
 								 FALSE, 0, 0, NULL, NULL, 0);
 	/* create ESP proposals with and without DH groups, let responder decide
 	 * if PFS is used */


### PR DESCRIPTION
Change both the dpd_action and close_action to ACTION_NONE
to prevent the client from trying to reestablish the VPN
automatically without explicitly being told to.
